### PR TITLE
Use PtrToStringBSTR for *nix compatibility

### DIFF
--- a/Public/New-PartnerAccessTokenLW.ps1
+++ b/Public/New-PartnerAccessTokenLW.ps1
@@ -9,7 +9,7 @@ function global:New-PartnerAccessTokenLW {
 	
     if ($Credential) {
 		$bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Credential.password)
-		$AppPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+		$AppPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
         $AuthBody = @{
             client_id     = $ApplicationId
             scope         = $Scopes


### PR DESCRIPTION
Changing PtrToStringAuto to PtrToStringBSTR allows this module to work on macOS and Linux.